### PR TITLE
fix ansible.lsb

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -19,14 +19,14 @@
 - name: Install OpenERP dependencies (Debian >= 7)
   apt:  pkg=python-babel
         state=installed
-  when: ansible_os_family == "Debian" and ansible_distribution_version.split(".")[0]|int >= 7
+  when: ansible_distribution == 'Debian' and ansible_distribution_version is version('7.0', '>=')
   tags:
     - openerp_packages
 
 - name: Install OpenERP dependencies (Debian < 7)
   apt:  pkg=python-pybabel
         state=installed
-  when: ansible_os_family == "Debian" and ansible_distribution_version.split(".")[0]|int < 7
+  when: ansible_distribution == 'Debian' and ansible_distribution_version is version('7.0', '<')
   tags:
     - openerp_packages
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -19,14 +19,14 @@
 - name: Install OpenERP dependencies (Debian >= 7)
   apt:  pkg=python-babel
         state=installed
-  when: ansible_os_family == "Debian" and ansible_lsb.major_release|int >= 7
+  when: ansible_os_family == "Debian" and ansible_distribution_version.split(".")[0]|int >= 7
   tags:
     - openerp_packages
 
 - name: Install OpenERP dependencies (Debian < 7)
   apt:  pkg=python-pybabel
         state=installed
-  when: ansible_os_family == "Debian" and ansible_lsb.major_release|int < 7
+  when: ansible_os_family == "Debian" and ansible_distribution_version.split(".")[0]|int < 7
   tags:
     - openerp_packages
 


### PR DESCRIPTION
Change of variable `ansible.lsb` to `ansible_distribution_version.split(".")[0]` on install.yml 

```
There are synchronicity issues with installing redhat-lsb-core (for example) and actually accessing ansible_lsb. Unless your node ALREADY has lsb installed BEFORE you run the playbook you'll be risking the ansible_lsb throwing an undifined error. It doesn't matter whether you check if the binary is now on the node, or even if you use a wait_for or time command. It'll fail the playbook and only be available when you RErun the playbook.
```
[source](https://groups.google.com/forum/#!topic/ansible-project/MuTD7nd5Zcc)
